### PR TITLE
Prevent errors when cache file does not yet exist

### DIFF
--- a/src/Storage/Adapter.php
+++ b/src/Storage/Adapter.php
@@ -80,8 +80,11 @@ class Adapter extends AbstractCache
      */
     public function load()
     {
-        if (($file = $this->adapter->read($this->file)) !== null) {
-            $this->setFromStorage($file['contents']);
+        if ($this->adapter->has($this->file)) {
+            $file = $this->adapter->read($this->file);
+            if ($file && !empty($file['contents'])) {
+                $this->setFromStorage($file['contents']);
+            }
         }
     }
 

--- a/tests/AdapterCacheTests.php
+++ b/tests/AdapterCacheTests.php
@@ -7,7 +7,7 @@ class AdapterCacheTests extends PHPUnit_Framework_TestCase
     public function testLoadFail()
     {
         $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
-        $adapter->shouldReceive('read')->once()->with('file.json')->andReturn(null);
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(false);
         $cache = new Adapter($adapter, 'file.json', 10);
         $cache->load();
         $this->assertFalse($cache->isComplete('', false));
@@ -17,6 +17,7 @@ class AdapterCacheTests extends PHPUnit_Framework_TestCase
     {
         $response = ['contents' => json_encode([[], ['' => true], 1234567890]), 'path' => 'file.json'];
         $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(true);
         $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
         $adapter->shouldReceive('delete')->once()->with('file.json');
         $cache = new Adapter($adapter, 'file.json', 10);
@@ -28,6 +29,7 @@ class AdapterCacheTests extends PHPUnit_Framework_TestCase
     {
         $response = ['contents' => json_encode([[], ['' => true], 9876543210]), 'path' => 'file.json'];
         $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(true);
         $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
         $cache = new Adapter($adapter, 'file.json', 10);
         $cache->load();


### PR DESCRIPTION
Adapter storage was not verifying that the cache file exists before it attempted to load it, which throws an exception, preventing the usage of Adapter storage.

Possibly related to #4.
