### PR TITLE
Fix AbstractCache::has assuming $path is a string

### DIFF
--- a/src/Storage/AbstractCache.php
+++ b/src/Storage/AbstractCache.php
@@ -146,7 +146,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function has($path)
     {
-        if (array_key_exists($path, $this->cache)) {
+        if ($path !== false && array_key_exists($path, $this->cache)) {
             return $this->cache[$path] !== false;
         }
 


### PR DESCRIPTION
If `$path` is a value that can't be an array key (e.g. `false`) then the
`array_key_exists` check will error out. This can happen when a
`Util::pathinfo()` call is made with a non-string parameter (e.g. `false`).
