### PR TITLE
add getCache() getter

### DIFF
--- a/src/CachedAdapter.php
+++ b/src/CachedAdapter.php
@@ -31,11 +31,23 @@ class CachedAdapter implements AdapterInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Get the underlying Adapter implementation.
+     *
+     * @return AdapterInterface
      */
     public function getAdapter()
     {
         return $this->adapter;
+    }
+    
+    /**
+     * Get the used Cache implementation.
+     *
+     * @return CacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
     }
 
     /**


### PR DESCRIPTION
Expose the cache, so implementations using the Adapter can flush if needed.

Fixes #3
