### PR TITLE
Memcached::isComplete() should always be false

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -9,6 +9,9 @@ interface CacheInterface extends ReadInterface
     /**
      * Check whether the directory listing of a given directory is complete.
      *
+     * Cache adapters that don't have reliable storage (like memcache) should
+     * always return false in this method.
+     *
      * @param string $dirname
      * @param bool   $recursive
      *

--- a/src/Storage/Memcached.php
+++ b/src/Storage/Memcached.php
@@ -56,4 +56,18 @@ class Memcached extends AbstractCache
         $expiration = $this->expire === null ? 0 : time() + $this->expire;
         $this->memcached->set($this->key, $contents, $expiration);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isComplete($dirname, $recursive) {
+        return FALSE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setComplete($dirname, $recursive) {
+        // The memcache adapter can never be complete due to cache evictions.
+    }
 }

--- a/tests/MemcachedTests.php
+++ b/tests/MemcachedTests.php
@@ -17,18 +17,31 @@ class MemcachedTests extends PHPUnit_Framework_TestCase
         $this->assertFalse($cache->isComplete('', false));
     }
 
+    /**
+     * Test that data can be loaded and retrieved from the cache.
+     */
     public function testLoadSuccess()
     {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('HHVM has a bug breaking mockery');
         }
 
-        $response = json_encode([[], ['' => true]]);
+        $cachedData = [
+            'test' => [
+                'dirname' => '',
+                'basename' => 'test',
+                'filename' => 'test',
+                'path' => 'test',
+                'type' => 'dir',
+            ],
+        ];
+
+        $response = json_encode([$cachedData, []]);
         $client = Mockery::mock('Memcached');
         $client->shouldReceive('get')->once()->andReturn($response);
         $cache = new Memcached($client);
         $cache->load();
-        $this->assertTrue($cache->isComplete('', false));
+        $this->assertEquals($cachedData['test'], $cache->getMetadata('test'));
     }
 
     public function testSave()
@@ -42,5 +55,15 @@ class MemcachedTests extends PHPUnit_Framework_TestCase
         $client->shouldReceive('set')->once()->andReturn($response);
         $cache = new Memcached($client);
         $cache->save();
+    }
+
+    /**
+     * Test that the memcache driver never ensures complete data.
+     */
+    public function testNeverComplete() {
+        $client = Mockery::mock('Memcached');
+        $cache = new Memcached($client);
+        $cache->setComplete('test', true);
+        $this->assertFalse($cache->isComplete('test', true));
     }
 }

--- a/tests/MemoryCacheTests.php
+++ b/tests/MemoryCacheTests.php
@@ -212,7 +212,7 @@ class MemoryCacheTests extends PHPUnit_Framework_TestCase
         $this->assertTrue($cache->has('newpath.txt'));
     }
 
-    public function testComplextListContents()
+    public function testComplexListContents()
     {
         $cache = new Memory();
         $cache->storeContents('', [


### PR DESCRIPTION
I realized that out of all the shipped adapters, memcache is really the only one that doesn't have reliable storage. This PR addresses #20 's concerns entirely within the memcache adapter.
