### PR TITLE
Set type where appropriate.

### DIFF
--- a/spec/CachedAdapterSpec.php
+++ b/spec/CachedAdapterSpec.php
@@ -43,10 +43,11 @@ class CachedAdapterSpec extends ObjectBehavior
 
     public function it_should_cache_writes()
     {
+        $type = 'file';
         $path = 'path.txt';
         $contents = 'contents';
         $config = new Config();
-        $response = compact('path', 'contents');
+        $response = compact('path', 'contents', 'type');
         $this->adapter->write($path, $contents, $config)->willReturn($response);
         $this->cache->updateObject($path, $response, true)->shouldBeCalled();
         $this->write($path, $contents, $config)->shouldBe($response);
@@ -54,10 +55,11 @@ class CachedAdapterSpec extends ObjectBehavior
 
     public function it_should_cache_streamed_writes()
     {
+        $type = 'file';
         $path = 'path.txt';
         $stream = tmpfile();
         $config = new Config();
-        $response = compact('path', 'stream');
+        $response = compact('path', 'stream', 'type');
         $this->adapter->writeStream($path, $stream, $config)->willReturn($response);
         $this->cache->updateObject($path, ['contents' => false] + $response, true)->shouldBeCalled();
         $this->writeStream($path, $stream, $config)->shouldBe($response);
@@ -66,10 +68,11 @@ class CachedAdapterSpec extends ObjectBehavior
 
     public function it_should_cache_streamed_updates()
     {
+        $type = 'file';
         $path = 'path.txt';
         $stream = tmpfile();
         $config = new Config();
-        $response = compact('path', 'stream');
+        $response = compact('path', 'stream', 'type');
         $this->adapter->updateStream($path, $stream, $config)->willReturn($response);
         $this->cache->updateObject($path, ['contents' => false] + $response, true)->shouldBeCalled();
         $this->updateStream($path, $stream, $config)->shouldBe($response);
@@ -97,10 +100,11 @@ class CachedAdapterSpec extends ObjectBehavior
 
     public function it_should_cache_updated()
     {
+        $type = 'file';
         $path = 'path.txt';
         $contents = 'contents';
         $config = new Config();
-        $response = compact('path', 'contents');
+        $response = compact('path', 'contents', 'type');
         $this->adapter->update($path, $contents, $config)->willReturn($response);
         $this->cache->updateObject($path, $response, true)->shouldBeCalled();
         $this->update($path, $contents, $config)->shouldBe($response);

--- a/src/CachedAdapter.php
+++ b/src/CachedAdapter.php
@@ -39,7 +39,7 @@ class CachedAdapter implements AdapterInterface
     {
         return $this->adapter;
     }
-    
+
     /**
      * Get the used Cache implementation.
      *
@@ -58,6 +58,7 @@ class CachedAdapter implements AdapterInterface
         $result = $this->adapter->write($path, $contents, $config);
 
         if ($result !== false) {
+            $result['type'] = 'file';
             $this->cache->updateObject($path, $result + compact('path', 'contents'), true);
         }
 
@@ -72,6 +73,7 @@ class CachedAdapter implements AdapterInterface
         $result = $this->adapter->writeStream($path, $resource, $config);
 
         if ($result !== false) {
+            $result['type'] = 'file';
             $contents = false;
             $this->cache->updateObject($path, $result + compact('path', 'contents'), true);
         }
@@ -87,6 +89,7 @@ class CachedAdapter implements AdapterInterface
         $result = $this->adapter->update($path, $contents, $config);
 
         if ($result !== false) {
+            $result['type'] = 'file';
             $this->cache->updateObject($path, $result + compact('path', 'contents'), true);
         }
 
@@ -101,6 +104,7 @@ class CachedAdapter implements AdapterInterface
         $result = $this->adapter->updateStream($path, $resource, $config);
 
         if ($result !== false) {
+            $result['type'] = 'file';
             $contents = false;
             $this->cache->updateObject($path, $result + compact('path', 'contents'), true);
         }


### PR DESCRIPTION
As mentioned in https://github.com/thephpleague/flysystem/issues/724, we should force the type during certain operations.

Adapters should probably be fixed as well, but this should help.