### PR TITLE
Fix path-directory calculations.

### DIFF
--- a/tests/AdapterCacheTests.php
+++ b/tests/AdapterCacheTests.php
@@ -55,4 +55,49 @@ class AdapterCacheTests extends PHPUnit_Framework_TestCase
         $cache = new Adapter($adapter, 'file.json', null);
         $cache->save();
     }
+
+    public function testStoreContentsRecursive()
+    {
+        $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(false);
+        $adapter->shouldReceive('write')->once()->with('file.json', Mockery::any(), Mockery::any());
+
+        $cache = new Adapter($adapter, 'file.json', null);
+
+        $contents = [
+            ['path' => 'foo/bar', 'dirname' => 'foo'],
+            ['path' => 'afoo/bang', 'dirname' => 'afoo'],
+        ];
+
+        $cache->storeContents('foo', $contents, true);
+
+        $this->assertTrue($cache->isComplete('foo', true));
+        $this->assertFalse($cache->isComplete('afoo', true));
+    }
+
+    public function testDeleteDir()
+    {
+        $cache_data = [
+            'foo' => ['path' => 'foo', 'type' => 'dir', 'dirname' => ''],
+            'foo/bar' => ['path' => 'foo/bar', 'type' => 'file', 'dirname' => 'foo'],
+            'foobaz' => ['path' => 'foobaz', 'type' => 'file', 'dirname' => ''],
+        ];
+
+        $response = [
+            'contents' => json_encode([$cache_data, [], null]),
+            'path' => 'file.json',
+        ];
+
+        $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->zeroOrMoreTimes()->with('file.json')->andReturn(true);
+        $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
+        $adapter->shouldReceive('update')->once()->with('file.json', Mockery::any(), Mockery::any())->andReturn(true);
+
+        $cache = new Adapter($adapter, 'file.json', null);
+        $cache->load();
+
+        $cache->deleteDir('foo', true);
+
+        $this->assertSame(1, count($cache->listContents('', true)));
+    }
 }


### PR DESCRIPTION
Fixes several problems with calculating sub-directories.

Also, removes unnecessary recursion `AbstractCache::listContents()`.

Tried to illustrate the problems with test cases, not sure if they're clear.