### PR TITLE
Fixed incompatible declaration of Noop::storeContents in php7.2

### DIFF
--- a/src/Storage/Noop.php
+++ b/src/Storage/Noop.php
@@ -52,7 +52,7 @@ class Noop extends AbstractCache
     /**
      * {@inheritdoc}
      */
-    public function storeContents($directory, array $contents, $recursive)
+    public function storeContents($directory, array $contents, $recursive = false)
     {
         return $contents;
     }


### PR DESCRIPTION
See the reason:

https://3v4l.org/VDT0P

The behavior was changed with this PR: https://github.com/php/php-src/pull/2342 but somehow got left undocumented in upgrade file.