### PR TITLE
expose adapter getPathPrefix() and applyPathPrefix($path) methods

### DIFF
--- a/src/CachedAdapter.php
+++ b/src/CachedAdapter.php
@@ -238,6 +238,28 @@ class CachedAdapter implements AdapterInterface
     }
 
     /**
+     * Get the path prefix.
+     *
+     * @return string|null path prefix or null if pathPrefix is empty
+     */
+    public function getPathPrefix()
+    {
+        return $this->adapter->getPathPrefix();
+    }
+
+    /**
+     * Prefix a path.
+     *
+     * @param string $path
+     *
+     * @return string prefixed path
+     */
+    public function applyPathPrefix($path)
+    {
+        return $this->adapter->applyPathPrefix($path);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function listContents($directory = '', $recursive = false)


### PR DESCRIPTION
this fixes  "Call to undefined method League\Flysystem\Cached\CachedAdapter::getPathPrefix ()" errors when attempting to call getPathPrefix/applyPathPrefix on a cached adapter.

Laravel's Storage::path() method calls getPathPrefix() internally for getting paths, which throws the above error if the disk is cached.