### PR TITLE
Use checks from AbstractCache to ensure data is valid on load

### DIFF
--- a/src/Storage/Adapter.php
+++ b/src/Storage/Adapter.php
@@ -67,11 +67,13 @@ class Adapter extends AbstractCache
     {
         list($cache, $complete, $expire) = json_decode($json, true);
 
-        if (! $expire || $expire > $this->getTime()) {
+        if (json_last_error() === JSON_ERROR_NONE && is_array($cache) && is_array($complete)) {
+            if (! $expire || $expire > $this->getTime()) {
             $this->cache = is_array($cache) ? $cache : [];
             $this->complete = is_array($complete) ? $complete : [];
-        } else {
-            $this->adapter->delete($this->file);
+            } else {
+                $this->adapter->delete($this->file);
+            }
         }
     }
 

--- a/tests/AdapterCacheTests.php
+++ b/tests/AdapterCacheTests.php
@@ -14,6 +14,39 @@ class AdapterCacheTests extends TestCase
         $this->assertFalse($cache->isComplete('', false));
     }
 
+    public function testLoadInvalidJson()
+    {
+        $response = ['contents' => 'invalid json', 'path' => 'file.json'];
+        $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(true);
+        $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
+        $cache = new Adapter($adapter, 'file.json', 10);
+        $cache->load();
+        $this->assertFalse($cache->isComplete('', false));
+    }
+
+    public function testLoadInvalidDataCacheIsNotAnArray()
+    {
+        $response = ['contents' => json_encode([null, ['' => true], 9876543210]), 'path' => 'file.json'];
+        $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(true);
+        $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
+        $cache = new Adapter($adapter, 'file.json', 10);
+        $cache->load();
+        $this->assertFalse($cache->isComplete('', false));
+    }
+
+    public function testLoadInvalidDataCompleteIsNotAnArray()
+    {
+        $response = ['contents' => json_encode([[], null, 9876543210]), 'path' => 'file.json'];
+        $adapter = Mockery::mock('League\Flysystem\AdapterInterface');
+        $adapter->shouldReceive('has')->once()->with('file.json')->andReturn(true);
+        $adapter->shouldReceive('read')->once()->with('file.json')->andReturn($response);
+        $cache = new Adapter($adapter, 'file.json', 10);
+        $cache->load();
+        $this->assertFalse($cache->isComplete('', false));
+    }
+
     public function testLoadExpired()
     {
         $response = ['contents' => json_encode([[], ['' => true], 1234567890]), 'path' => 'file.json'];


### PR DESCRIPTION
In some cases we get the following warning in our application:

```
Warning: array_key_exists() expects parameter 2 to be array, null given`
```

The only possible reason I found for this issue is, that invalid data has been read while loading, because `Adapter` is less strict than its base class `AbstractAdapter`. So I copied the missing checks to the `Adapter` class and added some tests.