### PR TITLE
Added config option to allow case_sensitive setting

### DIFF
--- a/src/Storage/AbstractCache.php
+++ b/src/Storage/AbstractCache.php
@@ -94,7 +94,7 @@ abstract class AbstractCache implements CacheInterface
         foreach ($contents as $object) {
             $this->updateObject($object['path'], $object);
 
-            $object = $this->cache[$this->case($object['path'])];
+            $object = $this->cache[$this->pathCase($object['path'])];
 
             if ($recursive && $this->pathIsInDirectory($directory, $object['path'])) {
                 $directories[] = $object['dirname'];
@@ -117,7 +117,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function updateObject($path, array $object, $autosave = false)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (! $this->has($path)) {
             $this->cache[$key] = Util::pathinfo($path);
@@ -139,7 +139,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function storeMiss($path)
     {
-        $this->cache[$this->case($path)] = false;
+        $this->cache[$this->pathCase($path)] = false;
         $this->autosave();
     }
 
@@ -153,7 +153,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function listContents($dirname = '', $recursive = false)
     {
-        $key = $this->case($dirname);
+        $key = $this->pathCase($dirname);
         $result = [];
 
         foreach ($this->cache as $object) {
@@ -161,7 +161,7 @@ abstract class AbstractCache implements CacheInterface
                 continue;
             }
 
-            if ($this->case($object['dirname']) === $key) {
+            if ($this->pathCase($object['dirname']) === $key) {
                 $result[] = $object;
             } elseif ($recursive && $this->pathIsInDirectory($key, $object['path'])) {
                 $result[] = $object;
@@ -176,7 +176,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function has($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if ($path !== false && array_key_exists($key, $this->cache)) {
             return $this->cache[$key] !== false;
@@ -192,7 +192,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function read($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['contents']) && $this->cache[$key]['contents'] !== false) {
             return $this->cache[$key];
@@ -218,7 +218,7 @@ abstract class AbstractCache implements CacheInterface
             return;
         }
 
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
         $object = $this->cache[$key];
 
         unset($this->cache[$key]);
@@ -226,7 +226,7 @@ abstract class AbstractCache implements CacheInterface
         $object['path'] = $newpath;
         $object = array_merge($object, Util::pathinfo($newpath));
 
-        $this->cache[$this->case($newpath)] = $object;
+        $this->cache[$this->pathCase($newpath)] = $object;
         $this->autosave();
     }
 
@@ -239,7 +239,7 @@ abstract class AbstractCache implements CacheInterface
             return;
         }
 
-        $object = $this->cache[$this->case($path)];
+        $object = $this->cache[$this->pathCase($path)];
         $object = array_merge($object, Util::pathinfo($newpath));
 
         $this->updateObject($newpath, $object, true);
@@ -258,10 +258,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function deleteDir($dirname)
     {
-        $dirname = $this->case($dirname);
+        $dirname = $this->pathCase($dirname);
 
         foreach ($this->cache as $path => $object) {
-            $key = $this->case($path);
+            $key = $this->pathCase($path);
 
             if ($this->pathIsInDirectory($dirname, $path) || $key === $dirname) {
                 unset($this->cache[$key]);
@@ -278,7 +278,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getMimetype($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['mimetype'])) {
             return $this->cache[$key];
@@ -298,7 +298,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getSize($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['size'])) {
             return $this->cache[$key];
@@ -312,7 +312,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getTimestamp($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['timestamp'])) {
             return $this->cache[$key];
@@ -326,7 +326,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getVisibility($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['visibility'])) {
             return $this->cache[$key];
@@ -340,7 +340,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getMetadata($path)
     {
-        $key = $this->case($path);
+        $key = $this->pathCase($path);
 
         if (isset($this->cache[$key]['type'])) {
             return $this->cache[$key];
@@ -354,7 +354,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function isComplete($dirname, $recursive)
     {
-        $key = $this->case($dirname);
+        $key = $this->pathCase($dirname);
 
         if (! array_key_exists($key, $this->complete)) {
             return false;
@@ -372,7 +372,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function setComplete($dirname, $recursive)
     {
-        $this->complete[$this->case($dirname)] = $recursive ? 'recursive' : true;
+        $this->complete[$this->pathCase($dirname)] = $recursive ? 'recursive' : true;
     }
 
     /**
@@ -392,7 +392,7 @@ abstract class AbstractCache implements CacheInterface
 
         foreach ($contents as $path => $object) {
             if (is_array($object)) {
-                $contents[$this->case($path)] = array_intersect_key($object, $cachedProperties);
+                $contents[$this->pathCase($path)] = array_intersect_key($object, $cachedProperties);
             }
         }
 
@@ -453,12 +453,12 @@ abstract class AbstractCache implements CacheInterface
      */
     public function ensureParentDirectories($path)
     {
-        $object = $this->cache[$this->case($path)];
+        $object = $this->cache[$this->pathCase($path)];
 
-        while ($object['dirname'] !== '' && ! isset($this->cache[$this->case($object['dirname'])])) {
+        while ($object['dirname'] !== '' && ! isset($this->cache[$this->pathCase($object['dirname'])])) {
             $object = Util::pathinfo($object['dirname']);
             $object['type'] = 'dir';
-            $this->cache[$this->case($object['path'])] = $object;
+            $this->cache[$this->pathCase($object['path'])] = $object;
         }
     }
 
@@ -472,7 +472,7 @@ abstract class AbstractCache implements CacheInterface
      */
     protected function pathIsInDirectory($directory, $path)
     {
-        return $directory === '' || strpos($this->case($path), $this->case($directory) . '/') === 0;
+        return $directory === '' || strpos($this->pathCase($path), $this->pathCase($directory) . '/') === 0;
     }
 
     /**
@@ -482,7 +482,7 @@ abstract class AbstractCache implements CacheInterface
      *
      * @return string
      */
-    protected function case($path)
+    protected function pathCase($path)
     {
         if ($this->config && $this->config->get('case_sensitive', true) === false) {
             $path = strtolower($path);

--- a/src/Storage/AbstractCache.php
+++ b/src/Storage/AbstractCache.php
@@ -3,6 +3,7 @@
 namespace League\Flysystem\Cached\Storage;
 
 use League\Flysystem\Cached\CacheInterface;
+use League\Flysystem\Config;
 use League\Flysystem\Util;
 
 abstract class AbstractCache implements CacheInterface
@@ -23,6 +24,11 @@ abstract class AbstractCache implements CacheInterface
     protected $complete = [];
 
     /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
      * Destructor.
      */
     public function __destruct()
@@ -30,6 +36,26 @@ abstract class AbstractCache implements CacheInterface
         if (! $this->autosave) {
             $this->save();
         }
+    }
+
+    /**
+     * Get the config object or null.
+     *
+     * @return Config|null config
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * Set the config.
+     *
+     * @param Config|array|null $config
+     */
+    public function setConfig($config)
+    {
+        $this->config = Util::ensureConfig($config);
     }
 
     /**
@@ -67,7 +93,8 @@ abstract class AbstractCache implements CacheInterface
 
         foreach ($contents as $object) {
             $this->updateObject($object['path'], $object);
-            $object = $this->cache[$object['path']];
+
+            $object = $this->cache[$this->case($object['path'])];
 
             if ($recursive && $this->pathIsInDirectory($directory, $object['path'])) {
                 $directories[] = $object['dirname'];
@@ -90,11 +117,13 @@ abstract class AbstractCache implements CacheInterface
      */
     public function updateObject($path, array $object, $autosave = false)
     {
+        $key = $this->case($path);
+
         if (! $this->has($path)) {
-            $this->cache[$path] = Util::pathinfo($path);
+            $this->cache[$key] = Util::pathinfo($path);
         }
 
-        $this->cache[$path] = array_merge($this->cache[$path], $object);
+        $this->cache[$key] = array_merge($this->cache[$key], $object);
 
         if ($autosave) {
             $this->autosave();
@@ -110,7 +139,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function storeMiss($path)
     {
-        $this->cache[$path] = false;
+        $this->cache[$this->case($path)] = false;
         $this->autosave();
     }
 
@@ -124,15 +153,17 @@ abstract class AbstractCache implements CacheInterface
      */
     public function listContents($dirname = '', $recursive = false)
     {
+        $key = $this->case($dirname);
         $result = [];
 
         foreach ($this->cache as $object) {
             if ($object === false) {
                 continue;
             }
-            if ($object['dirname'] === $dirname) {
+
+            if ($this->case($object['dirname']) === $key) {
                 $result[] = $object;
-            } elseif ($recursive && $this->pathIsInDirectory($dirname, $object['path'])) {
+            } elseif ($recursive && $this->pathIsInDirectory($key, $object['path'])) {
                 $result[] = $object;
             }
         }
@@ -145,8 +176,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function has($path)
     {
-        if ($path !== false && array_key_exists($path, $this->cache)) {
-            return $this->cache[$path] !== false;
+        $key = $this->case($path);
+
+        if ($path !== false && array_key_exists($key, $this->cache)) {
+            return $this->cache[$key] !== false;
         }
 
         if ($this->isComplete(Util::dirname($path), false)) {
@@ -159,8 +192,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function read($path)
     {
-        if (isset($this->cache[$path]['contents']) && $this->cache[$path]['contents'] !== false) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['contents']) && $this->cache[$key]['contents'] !== false) {
+            return $this->cache[$key];
         }
 
         return false;
@@ -179,14 +214,20 @@ abstract class AbstractCache implements CacheInterface
      */
     public function rename($path, $newpath)
     {
-        if ($this->has($path)) {
-            $object = $this->cache[$path];
-            unset($this->cache[$path]);
-            $object['path'] = $newpath;
-            $object = array_merge($object, Util::pathinfo($newpath));
-            $this->cache[$newpath] = $object;
-            $this->autosave();
+        if (!$this->has($path)) {
+            return;
         }
+
+        $key = $this->case($path);
+        $object = $this->cache[$key];
+
+        unset($this->cache[$key]);
+
+        $object['path'] = $newpath;
+        $object = array_merge($object, Util::pathinfo($newpath));
+
+        $this->cache[$this->case($newpath)] = $object;
+        $this->autosave();
     }
 
     /**
@@ -194,11 +235,14 @@ abstract class AbstractCache implements CacheInterface
      */
     public function copy($path, $newpath)
     {
-        if ($this->has($path)) {
-            $object = $this->cache[$path];
-            $object = array_merge($object, Util::pathinfo($newpath));
-            $this->updateObject($newpath, $object, true);
+        if (!$this->has($path)) {
+            return;
         }
+
+        $object = $this->cache[$this->case($path)];
+        $object = array_merge($object, Util::pathinfo($newpath));
+
+        $this->updateObject($newpath, $object, true);
     }
 
     /**
@@ -214,9 +258,13 @@ abstract class AbstractCache implements CacheInterface
      */
     public function deleteDir($dirname)
     {
+        $dirname = $this->case($dirname);
+
         foreach ($this->cache as $path => $object) {
-            if ($this->pathIsInDirectory($dirname, $path) || $path === $dirname) {
-                unset($this->cache[$path]);
+            $key = $this->case($path);
+
+            if ($this->pathIsInDirectory($dirname, $path) || $key === $dirname) {
+                unset($this->cache[$key]);
             }
         }
 
@@ -230,18 +278,19 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getMimetype($path)
     {
-        if (isset($this->cache[$path]['mimetype'])) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['mimetype'])) {
+            return $this->cache[$key];
         }
 
         if (! $result = $this->read($path)) {
             return false;
         }
 
-        $mimetype = Util::guessMimeType($path, $result['contents']);
-        $this->cache[$path]['mimetype'] = $mimetype;
+        $this->cache[$key]['mimetype'] = Util::guessMimeType($path, $result['contents']);
 
-        return $this->cache[$path];
+        return $this->cache[$key];
     }
 
     /**
@@ -249,8 +298,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getSize($path)
     {
-        if (isset($this->cache[$path]['size'])) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['size'])) {
+            return $this->cache[$key];
         }
 
         return false;
@@ -261,8 +312,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getTimestamp($path)
     {
-        if (isset($this->cache[$path]['timestamp'])) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['timestamp'])) {
+            return $this->cache[$key];
         }
 
         return false;
@@ -273,8 +326,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getVisibility($path)
     {
-        if (isset($this->cache[$path]['visibility'])) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['visibility'])) {
+            return $this->cache[$key];
         }
 
         return false;
@@ -285,8 +340,10 @@ abstract class AbstractCache implements CacheInterface
      */
     public function getMetadata($path)
     {
-        if (isset($this->cache[$path]['type'])) {
-            return $this->cache[$path];
+        $key = $this->case($path);
+
+        if (isset($this->cache[$key]['type'])) {
+            return $this->cache[$key];
         }
 
         return false;
@@ -297,11 +354,13 @@ abstract class AbstractCache implements CacheInterface
      */
     public function isComplete($dirname, $recursive)
     {
-        if (! array_key_exists($dirname, $this->complete)) {
+        $key = $this->case($dirname);
+
+        if (! array_key_exists($key, $this->complete)) {
             return false;
         }
 
-        if ($recursive && $this->complete[$dirname] !== 'recursive') {
+        if ($recursive && $this->complete[$key] !== 'recursive') {
             return false;
         }
 
@@ -313,7 +372,7 @@ abstract class AbstractCache implements CacheInterface
      */
     public function setComplete($dirname, $recursive)
     {
-        $this->complete[$dirname] = $recursive ? 'recursive' : true;
+        $this->complete[$this->case($dirname)] = $recursive ? 'recursive' : true;
     }
 
     /**
@@ -333,7 +392,7 @@ abstract class AbstractCache implements CacheInterface
 
         foreach ($contents as $path => $object) {
             if (is_array($object)) {
-                $contents[$path] = array_intersect_key($object, $cachedProperties);
+                $contents[$this->case($path)] = array_intersect_key($object, $cachedProperties);
             }
         }
 
@@ -394,12 +453,12 @@ abstract class AbstractCache implements CacheInterface
      */
     public function ensureParentDirectories($path)
     {
-        $object = $this->cache[$path];
+        $object = $this->cache[$this->case($path)];
 
-        while ($object['dirname'] !== '' && ! isset($this->cache[$object['dirname']])) {
+        while ($object['dirname'] !== '' && ! isset($this->cache[$this->case($object['dirname'])])) {
             $object = Util::pathinfo($object['dirname']);
             $object['type'] = 'dir';
-            $this->cache[$object['path']] = $object;
+            $this->cache[$this->case($object['path'])] = $object;
         }
     }
 
@@ -413,6 +472,22 @@ abstract class AbstractCache implements CacheInterface
      */
     protected function pathIsInDirectory($directory, $path)
     {
-        return $directory === '' || strpos($path, $directory . '/') === 0;
+        return $directory === '' || strpos($this->case($path), $this->case($directory) . '/') === 0;
+    }
+
+    /**
+     * Return the path string checking case_sensitive config value
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function case($path)
+    {
+        if ($this->config && $this->config->get('case_sensitive', true) === false) {
+            $path = strtolower($path);
+        }
+
+        return $path;
     }
 }

--- a/src/Storage/Adapter.php
+++ b/src/Storage/Adapter.php
@@ -25,15 +25,17 @@ class Adapter extends AbstractCache
     /**
      * Constructor.
      *
-     * @param AdapterInterface $adapter adapter
-     * @param string           $file    the file to cache to
-     * @param int|null         $expire  seconds until cache expiration
+     * @param AdapterInterface  $adapter adapter
+     * @param string            $file    the file to cache to
+     * @param int|null          $expire  seconds until cache expiration
+     * @param Config|array|null $config  settings values
      */
-    public function __construct(AdapterInterface $adapter, $file, $expire = null)
+    public function __construct(AdapterInterface $adapter, $file, $expire = null, $config = [])
     {
         $this->adapter = $adapter;
         $this->file = $file;
         $this->setExpire($expire);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Storage/Memcached.php
+++ b/src/Storage/Memcached.php
@@ -24,15 +24,17 @@ class Memcached extends AbstractCache
     /**
      * Constructor.
      *
-     * @param \Memcached $memcached
-     * @param string     $key       storage key
-     * @param int|null   $expire    seconds until cache expiration
+     * @param \Memcached        $memcached
+     * @param string            $key       storage key
+     * @param int|null          $expire    seconds until cache expiration
+     * @param Config|array|null $config    settings values
      */
-    public function __construct(NativeMemcached $memcached, $key = 'flysystem', $expire = null)
+    public function __construct(NativeMemcached $memcached, $key = 'flysystem', $expire = null, $config = [])
     {
         $this->key = $key;
         $this->expire = $expire;
         $this->memcached = $memcached;
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Storage/PhpRedis.php
+++ b/src/Storage/PhpRedis.php
@@ -24,15 +24,17 @@ class PhpRedis extends AbstractCache
     /**
      * Constructor.
      *
-     * @param Redis|null $client phpredis client
-     * @param string     $key    storage key
-     * @param int|null   $expire seconds until cache expiration
+     * @param Redis|null        $client phpredis client
+     * @param string            $key    storage key
+     * @param int|null          $expire seconds until cache expiration
+     * @param Config|array|null $config settings values
      */
-    public function __construct(Redis $client = null, $key = 'flysystem', $expire = null)
+    public function __construct(Redis $client = null, $key = 'flysystem', $expire = null, $config = [])
     {
         $this->client = $client ?: new Redis();
         $this->key = $key;
         $this->expire = $expire;
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Storage/Predis.php
+++ b/src/Storage/Predis.php
@@ -24,15 +24,17 @@ class Predis extends AbstractCache
     /**
      * Constructor.
      *
-     * @param \Predis\Client $client predis client
-     * @param string         $key    storage key
-     * @param int|null       $expire seconds until cache expiration
+     * @param \Predis\Client    $client predis client
+     * @param string            $key    storage key
+     * @param int|null          $expire seconds until cache expiration
+     * @param Config|array|null $config settings values
      */
-    public function __construct(Client $client = null, $key = 'flysystem', $expire = null)
+    public function __construct(Client $client = null, $key = 'flysystem', $expire = null, $config = [])
     {
         $this->client = $client ?: new Client();
         $this->key = $key;
         $this->expire = $expire;
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Storage/Psr6Cache.php
+++ b/src/Storage/Psr6Cache.php
@@ -27,12 +27,14 @@ class Psr6Cache extends AbstractCache
      * @param CacheItemPoolInterface $pool
      * @param string                 $key    storage key
      * @param int|null               $expire seconds until cache expiration
+     * @param Config|array|null      $config settings values
      */
-    public function __construct(CacheItemPoolInterface $pool, $key = 'flysystem', $expire = null)
+    public function __construct(CacheItemPoolInterface $pool, $key = 'flysystem', $expire = null, $config = [])
     {
         $this->pool = $pool;
         $this->key = $key;
         $this->expire = $expire;
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Storage/Stash.php
+++ b/src/Storage/Stash.php
@@ -24,15 +24,17 @@ class Stash extends AbstractCache
     /**
      * Constructor.
      *
-     * @param \Stash\Pool $pool
-     * @param string      $key    storage key
-     * @param int|null    $expire seconds until cache expiration
+     * @param \Stash\Pool       $pool
+     * @param string            $key    storage key
+     * @param int|null          $expire seconds until cache expiration
+     * @param Config|array|null $config settings values
      */
-    public function __construct(Pool $pool, $key = 'flysystem', $expire = null)
+    public function __construct(Pool $pool, $key = 'flysystem', $expire = null, $config = [])
     {
         $this->key = $key;
         $this->expire = $expire;
         $this->pool = $pool;
+        $this->setConfig($config);
     }
 
     /**


### PR DESCRIPTION
This commit allow to config cache adapters with config settings as `case_sensitive`.

This feature allow to integrate cache to adapters like Dropbox (and others) that are case insensitive.

Tested on a current project that use https://github.com/spatie/flysystem-dropbox as Dropbox Adapter and this project as cache adapter.

All Cache Storage adapters allow a fourth parameter with an array of settings (currently only `case_sensitive`):

```php
$cache =  new Predis(null, $config['prefix'], $config['expire'], ['case_sensitive' => false]);
```